### PR TITLE
User Authentication: Identity-Aware Proxy - fix - max instance limit 

### DIFF
--- a/1-HelloWorld/app.yaml
+++ b/1-HelloWorld/app.yaml
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 runtime: python37
+automatic_scaling:
+  max_instances: 2

--- a/2-HelloUser/app.yaml
+++ b/2-HelloUser/app.yaml
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 runtime: python37
+automatic_scaling:
+  max_instances: 2

--- a/3-HelloVerifiedUser/app.yaml
+++ b/3-HelloVerifiedUser/app.yaml
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 runtime: python37
+automatic_scaling:
+  max_instances: 2


### PR DESCRIPTION
Code from this repository is used in this Qwiklabs task:  https://google.qwiklabs.com/focuses/5562?parent=catalog

In third step user always gets error message that maximum number of app instances is 10. Due to this it's impossible to finish the lab. 

This CL limits the numer of possible instances and allows students to finish the lab.
