### PR TITLE
Update app.yaml

### DIFF
--- a/3-HelloVerifiedUser/app.yaml
+++ b/3-HelloVerifiedUser/app.yaml
@@ -13,3 +13,9 @@
 # limitations under the License.
 
 runtime: python37
+automatic_scaling:
+  min_idle_instances: automatic
+  max_idle_instances: automatic
+  min_pending_latency: automatic
+  max_pending_latency: automatic
+  max_instances: 2


### PR DESCRIPTION
Setting a maximum number of instances to open for each project resolves the error “ERROR: (gcloud.app.deploy) INVALID_ARGUMENT: You may not have more than 10 total instances in your project ” while running the User Authentication: Identity-Aware Proxy lab